### PR TITLE
remove admin_ips from additional rules for Public Agents SG

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "additional_rules" {
   protocol    = "tcp"
   from_port   = "${element(local.public_agents_additional_ports, count.index)}"
   to_port     = "${element(local.public_agents_additional_ports, count.index)}"
-  cidr_blocks = ["${concat(var.admin_ips, var.public_agents_ips)}"]
+  cidr_blocks = ["${var.public_agents_ips}"]
 
   security_group_id = "${aws_security_group.public_agents.id}"
 }


### PR DESCRIPTION
Since we are setting the source for the Public Agent SG to 0.0.0.0/0 by default, we do not need to concat the admin_ips in addition. This is actually causing an error when users are defining 0.0.0.0/0 as their admin_ips. 

https://jira.mesosphere.com/browse/DT-12

Error: Error applying plan:

2 error(s) occurred:

module.dcos.module.dcos-infrastructure.module.dcos-security-groups.aws_security_group_rule.additional_rules[0]: 1 error(s) occurred:
aws_security_group_rule.additional_rules.0: Error authorizing security group rule type ingress: InvalidParameterValue: The same permission must not appear multiple times
status code: 400, request id: 019cec6c-1231-4af8-8013-b74337715f7b
module.dcos.module.dcos-infrastructure.module.dcos-security-groups.aws_security_group_rule.additional_rules[1]: 1 error(s) occurred:
aws_security_group_rule.additional_rules.1: Error authorizing security group rule type ingress: InvalidParameterValue: The same permission must not appear multiple times
status code: 400, request id: eac72fdf-8024-4ff8-a4e1-f455d8fc5d14

`The same permission must not appear multiple times
status code: 400`

This is due to applying the same source to the same port multiple times. 
