### PR TITLE
multi-region effort: dynamic security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,21 +36,21 @@ resource "aws_security_group" "internal" {
 }
 
 resource "aws_security_group_rule" "internal_ingress_rule" {
-  type            = "ingress"
-  from_port       = 0
-  to_port         = 0
-  protocol        = "-1"
+  type        = "ingress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
   cidr_blocks = ["${var.subnet_range}"]
 
   security_group_id = "${aws_security_group.internal.id}"
 }
 
 resource "aws_security_group_rule" "internal_egress_rule" {
-  type            = "egress"
-  from_port       = 0
-  to_port         = 0
-  protocol        = "-1"
-  cidr_blocks     = ["0.0.0.0/0"]
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.internal.id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "aws_security_group_rule" "internal_egress_rule" {
   type            = "egress"
   from_port       = 0
   to_port         = 0
-  protocol        = "tcp"
+  protocol        = "-1"
   cidr_blocks     = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.internal.id}"

--- a/main.tf
+++ b/main.tf
@@ -33,20 +33,26 @@ resource "aws_security_group" "internal" {
 
   tags = "${merge(var.tags, map("Name", var.cluster_name,
                                 "Cluster", var.cluster_name))}"
+}
 
-  ingress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["${var.subnet_range}"]
-  }
+resource "aws_security_group_rule" "internal_ingress_rule" {
+  type            = "ingress"
+  from_port       = 0
+  to_port         = 0
+  protocol        = "-1"
+  cidr_blocks = ["${var.subnet_range}"]
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  security_group_id = "${aws_security_group.internal.id}"
+}
+
+resource "aws_security_group_rule" "internal_egress_rule" {
+  type            = "egress"
+  from_port       = 0
+  to_port         = 0
+  protocol        = "tcp"
+  cidr_blocks     = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.internal.id}"
 }
 
 resource "aws_security_group" "master_lb" {


### PR DESCRIPTION
This enables the ability for users to dynamically append or delete security group entries to the internal security group. This will be a breaking change for the users because terraform does not process that the rule already exist and there is nothing to do.

This GH issue is being tracked here: https://github.com/terraform-providers/terraform-provider-aws/issues/7058


When a user plans to upgrade to this version which has the change, they will need to remove the existing rule and have terraform add it back in. Another option is to mutate a terraform.tfstate file, but this method  below works and is less risk averse IMHO.

```
AWS_DEFAULT_REGION=us-east-1 aws ec2 revoke-security-group-ingress --group-id $(terraform state show module.dcos.module.dcos-infrastructure.module.dcos-security-groups.aws_security_group.internal | grep -Eo sg-.\+\$ | tail -1) --ip-permissions '[{"IpProtocol": "-1", "IpRanges": [{"CidrIp": "172.12.0.0/16"}]}]'
AWS_DEFAULT_REGION=us-east-1 aws ec2 revoke-security-group-egress --group-id $(terraform state show module.dcos.module.dcos-infrastructure.module.dcos-security-groups.aws_security_group.internal | grep -Eo sg-.\+\$ | tail -1) --ip-permissions '[{"IpProtocol": "-1", "IpRanges": [{"CidrIp": "0.0.0.0/0"}]}]'
terraform apply
```


This command allows a user to see what is the current status of the security group.

```
AWS_DEFAULT_REGION=us-east-1  aws ec2 describe-security-groups --group-id $(terraform state show module.dcos.module.dcos-infrastructure.module.dcos-security-groups.aws_security_group.internal | grep -Eo sg-.\+\$ | tail -1)
```