### PR TITLE
Update variable to be more descriptive 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ module "dcos-security-groups" {
 |------|-------------|:----:|:-----:|:-----:|
 | admin_ips | List of CIDR admin IPs | list | - | yes |
 | cluster_name | Name of the DC/OS cluster | string | `aws-example` | no |
+| public_agents_access_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public_agents_additional_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |
-| public_agents_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | subnet_range | Private IP space to be used in CIDR format | string | - | yes |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 | vpc_id | AWS VPC ID | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "additional_rules" {
   protocol    = "tcp"
   from_port   = "${element(local.public_agents_additional_ports, count.index)}"
   to_port     = "${element(local.public_agents_additional_ports, count.index)}"
-  cidr_blocks = ["${var.public_agents_ips}"]
+  cidr_blocks = ["${var.public_agents_access_ips}"]
 
   security_group_id = "${aws_security_group.public_agents.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "admin_ips" {
   type        = "list"
 }
 
-variable "public_agents_ips" {
+variable "public_agents_access_ips" {
   description = "List of ips allowed access to public agents. admin_ips are joined to this list"
   type        = "list"
   default     = ["0.0.0.0/0"]


### PR DESCRIPTION
Users want to be able to add the ability to remove the default 0.0.0.0 on public agent security group and use specified IP range. This will address:

issue dcos-terraform/terraform-aws-dcos#40
JIRA Ticket: https://jira.mesosphere.com/browse/DCOS-47891

This PR is to make the variable more descriptive and more align with its purpose.