### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ module "dcos-security-groups" {
 | subnet\_range | Private IP space to be used in CIDR format | string | n/a | yes |
 | vpc\_id | AWS VPC ID | string | n/a | yes |
 | accepted\_internal\_networks | Subnet ranges for all internal networks | list | `<list>` | no |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | cluster\_name | Name of the DC/OS cluster | string | `"aws-example"` | no |
 | public\_agents\_access\_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public\_agents\_additional\_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,13 @@ resource "aws_security_group" "admin" {
   }
 
   ingress {
+    from_port   = "${var.adminrouter_grpc_proxy_port}"
+    to_port     = "${var.adminrouter_grpc_proxy_port}"
+    protocol    = "tcp"
+    cidr_blocks = ["${var.admin_ips}"]
+  }
+
+  ingress {
     from_port   = 3389
     to_port     = 3389
     protocol    = "tcp"

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,8 @@ variable "accepted_internal_networks" {
   type        = "list"
   default     = []
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476