### PR TITLE
add RFC6335 registered and dynamic ports for public agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ module "dcos-security-groups" {
 | cluster\_name | Name of the DC/OS cluster | string | `"aws-example"` | no |
 | public\_agents\_access\_ips | List of ips allowed access to public agents. admin_ips are joined to this list | list | `<list>` | no |
 | public\_agents\_additional\_ports | List of additional ports allowed for public access on public agents (80 and 443 open by default) | list | `<list>` | no |
+| public\_agents\_allow\_dynamic | Allow dynamic / ephemeral ports (49152-65535 see: RFC6335) on public agents public IPs | string | `"false"` | no |
+| public\_agents\_allow\_registered | Allow registered / user ports (1024-49151 see: RFC6335) on public agents public IPs | string | `"false"` | no |
 | tags | Add custom tags to all resources | map | `<map>` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,28 @@ resource "aws_security_group_rule" "additional_rules" {
   security_group_id = "${aws_security_group.public_agents.id}"
 }
 
+resource "aws_security_group_rule" "allow_registered" {
+  count       = "${var.public_agents_allow_registered}"
+  type        = "ingress"
+  protocol    = "-1"
+  from_port   = "1024"
+  to_port     = "49151"
+  cidr_blocks = ["${distinct(var.public_agents_access_ips)}"]
+
+  security_group_id = "${aws_security_group.public_agents.id}"
+}
+
+resource "aws_security_group_rule" "allow_dynamic" {
+  count       = "${var.public_agents_allow_dynamic}"
+  type        = "ingress"
+  protocol    = "-1"
+  from_port   = "49152"
+  to_port     = "65535"
+  cidr_blocks = ["${distinct(var.public_agents_access_ips)}"]
+
+  security_group_id = "${aws_security_group.public_agents.id}"
+}
+
 resource "aws_security_group" "admin" {
   name        = "dcos-${var.cluster_name}-admin-firewall"
   description = "Allow incoming traffic from admin_ips"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,16 @@ variable "public_agents_additional_ports" {
   default     = []
 }
 
+variable "public_agents_allow_registered" {
+  description = "Allow registered / user ports (1024-49151 see: RFC6335) on public agents public IPs"
+  default     = false
+}
+
+variable "public_agents_allow_dynamic" {
+  description = "Allow dynamic / ephemeral ports (49152-65535 see: RFC6335) on public agents public IPs"
+  default     = false
+}
+
 variable "accepted_internal_networks" {
   description = "Subnet ranges for all internal networks"
   type        = "list"


### PR DESCRIPTION
> TCP, UDP, UDP-Lite, SCTP, and DCCP use 16-bit namespaces for their
   port number registries.  The port registries for all of these
   transport protocols are subdivided into three ranges of numbers
   [RFC1340], and Section 8.1.2 describes the IANA procedures for each
   range in detail:
>
>   o  the System Ports, also known as the Well Known Ports, from 0-1023
      (assigned by IANA)
>
>   o  the User Ports, also known as the Registered Ports, from 1024-
      49151 (assigned by IANA)
>
>   o  the Dynamic Ports, also known as the Private or Ephemeral Ports,
      from 49152-65535 (never assigned)
> - http://www.rfc-editor.org/rfc/rfc6335.txt

adding registered and dynamic port option for public agents to let users open these ranges with a simple switch
